### PR TITLE
fix: useClientHeight hook cleanup

### DIFF
--- a/src/hooks/useClientHeight.tsx
+++ b/src/hooks/useClientHeight.tsx
@@ -16,7 +16,7 @@ function useClientHeight<A extends HTMLElement>(): [{ ref: MutableRefObject<A> }
 
         return () => {
             window.removeEventListener('resize', handleResize);
-            ref.current?.addEventListener('resize', handleResize);
+            ref.current?.removeEventListener('resize', handleResize);
         };
     }, []);
 


### PR DESCRIPTION
Fixes returned cleanup method inside `useClientHeight` hook