### PR TITLE
fix: disabled inputRef in InputField story playground controls

### DIFF
--- a/src/components/InputField/InputField.stories.mdx
+++ b/src/components/InputField/InputField.stories.mdx
@@ -42,7 +42,7 @@ export const inputWarningArgTypes = {
     },
 };
 
-export const disabledPropsInControl = {
+export const argTypes = {
     inputRef: { table: { disable: true } },
 };
 
@@ -74,7 +74,7 @@ export default InputFieldExample;
 ## Variants
 
 <Canvas>
-    <Story name="InputField" args={{ ...inputArgTypes }} argTypes={disabledPropsInControl}>
+    <Story name="InputField" args={{ ...inputArgTypes }} argTypes={argTypes}>
         {InputFieldTemplate.bind({})}
     </Story>
 </Canvas>
@@ -82,11 +82,7 @@ export default InputFieldExample;
 ### With Error Message
 
 <Canvas>
-    <Story
-        name="InputWarningField"
-        args={{ ...inputWarningArgTypes }}
-        argTypes={disabledPropsInControl}
-    >
+    <Story name="InputWarningField" args={{ ...inputWarningArgTypes }} argTypes={argTypes}>
         {InputFieldTemplate.bind({})}
     </Story>
 </Canvas>

--- a/src/components/InputField/InputField.stories.mdx
+++ b/src/components/InputField/InputField.stories.mdx
@@ -42,6 +42,10 @@ export const inputWarningArgTypes = {
     },
 };
 
+export const disabledPropsInControl = {
+    inputRef: { table: { disable: true } },
+};
+
 An input field includes a label and a text field users can type text into.
 
 ## Usage
@@ -70,7 +74,7 @@ export default InputFieldExample;
 ## Variants
 
 <Canvas>
-    <Story name="InputField" args={{ ...inputArgTypes }}>
+    <Story name="InputField" args={{ ...inputArgTypes }} argTypes={disabledPropsInControl}>
         {InputFieldTemplate.bind({})}
     </Story>
 </Canvas>
@@ -78,7 +82,11 @@ export default InputFieldExample;
 ### With Error Message
 
 <Canvas>
-    <Story name="InputWarningField" args={{ ...inputWarningArgTypes }}>
+    <Story
+        name="InputWarningField"
+        args={{ ...inputWarningArgTypes }}
+        argTypes={disabledPropsInControl}
+    >
         {InputFieldTemplate.bind({})}
     </Story>
 </Canvas>


### PR DESCRIPTION
Disabled **inputRef** prop in **InputField** story playground controls as it was throwing an error: "TypeError: Converting circular structure to JSON" which was breaking the UI.

<img width="665" alt="Screenshot 2022-07-08 at 1 24 52 PM" src="https://user-images.githubusercontent.com/35104014/177946183-d3c904a7-97d0-46c1-98ee-0d3427973ce0.png">

