### PR TITLE
chore: Remove nullish coalescing and optional chaining plugins

### DIFF
--- a/babel.config.json
+++ b/babel.config.json
@@ -1,4 +1,4 @@
 {
   "presets": ["@babel/preset-typescript", "@babel/preset-react", "@babel/preset-env"],
-  "plugins": ["macros", "preval", "babel-plugin-styled-components", "@babel/plugin-proposal-nullish-coalescing-operator", "@babel/plugin-proposal-optional-chaining"]
+  "plugins": ["macros", "preval", "babel-plugin-styled-components"]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,8 +17,6 @@
                 "@babel/cli": "^7.17.6",
                 "@babel/core": "^7.17.9",
                 "@babel/eslint-parser": "^7.17.0",
-                "@babel/plugin-proposal-nullish-coalescing-operator": "^7.16.7",
-                "@babel/plugin-proposal-optional-chaining": "^7.16.7",
                 "@babel/plugin-transform-modules-commonjs": "^7.17.9",
                 "@babel/preset-env": "^7.16.11",
                 "@babel/preset-react": "^7.16.7",

--- a/package.json
+++ b/package.json
@@ -79,8 +79,6 @@
         "@babel/cli": "^7.17.6",
         "@babel/core": "^7.17.9",
         "@babel/eslint-parser": "^7.17.0",
-        "@babel/plugin-proposal-nullish-coalescing-operator": "^7.16.7",
-        "@babel/plugin-proposal-optional-chaining": "^7.16.7",
         "@babel/plugin-transform-modules-commonjs": "^7.17.9",
         "@babel/preset-env": "^7.16.11",
         "@babel/preset-react": "^7.16.7",


### PR DESCRIPTION
Removed [`@babel/plugin-proposal-nullish-coalescing-operator`](https://babeljs.io/docs/en/babel-plugin-proposal-nullish-coalescing-operator) and [`@babel/plugin-proposal-optional-chaining`](https://babeljs.io/docs/en/babel-plugin-proposal-optional-chaining) plugins from *babel.config*, since both are included in `@babel/preset-env`.

![image](https://user-images.githubusercontent.com/42532987/178143606-82e145eb-da57-4299-b2eb-e51227e6f7bf.png)
![image](https://user-images.githubusercontent.com/42532987/178143731-86858872-5fa3-4afe-b877-dea07de1a30f.png)

