### PR TITLE
Fixed scoremeter readings limit check and playground controls

### DIFF
--- a/src/components/Scoremeter/Scoremeter.stories.mdx
+++ b/src/components/Scoremeter/Scoremeter.stories.mdx
@@ -33,35 +33,47 @@ export const LightScoreMeterTemplate = (args) => (
 
 export const ScoreMeterArgs = {
     reading: {
-        description: 'Current value of meter',
+        type: { name: 'number', required: true },
     },
-    meterConfig: {
-        description:
-            'All configs related to meter. meterColor: bar fill color, meterWrapper: outside meter wrapper bg, border: meter border, dotColor: dot color',
-    },
-    scoreConfig: {
-        description:
-            'All configs related to score. scoreDesc: description inside meter, scoreWrapper: space between bar with meterColor and scoreContainer, scoreContainer: score container background, scoreColor: score text color, showIndicators: indicators for score inc/dec.',
+    colorConfig: {
+        type: { name: 'object', required: false },
     },
     oldReading: {
-        description: 'Old reading (pass when score change animation required)',
+        defaultValue: null,
+        type: { name: 'number', required: false },
         control: {
             type: 'number',
         },
     },
     lowerLimit: {
-        description: 'Minimum possible reading of meter',
+        type: { name: 'number', required: false },
         defaultValue: 300,
         control: {
             type: 'number',
         },
     },
     upperLimit: {
-        description: 'Maximum possible reading of meter',
+        type: { name: 'number', required: false },
         defaultValue: 900,
         control: {
             type: 'number',
         },
+    },
+    type: {
+        options: ['excellent', 'average', 'poor'],
+        control: { type: 'radio', required: false },
+    },
+    colorMode: {
+        options: ['dark', 'light'],
+        control: { type: 'radio', required: false },
+    },
+    showIndicators: {
+        defaultValue: false,
+        control: { type: 'boolean', required: false },
+    },
+    showLegends: {
+        defaultValue: true,
+        control: { type: 'boolean', required: false },
     },
 };
 
@@ -123,7 +135,6 @@ export default ScoreMeterExample;
 
 <div style={{overflowX: 'auto'}}>
 
-
 | name             | description                                                                                                                          | type    |
 | ---------------- | ------------------------------------------------------------------------------------------------------------------------------------ | ------- |
 | `reading*`       | Current value of meter                                                                                                               | number  |
@@ -137,13 +148,11 @@ export default ScoreMeterExample;
 | `colorConfig`    | All configs related to color of the scoremeter                                                                                       | object  |
 | `showLegends`    | Use to show lower limit and upper limit text                                                                                         | boolean |
 
-
 </div>
 
 **colorConfig**
 
 <div style={{overflowX: 'auto'}}>
-
 
 | name                       | description                                                                  | type   |
 | -------------------------- | ---------------------------------------------------------------------------- | ------ |
@@ -156,20 +165,17 @@ export default ScoreMeterExample;
 | `scoreContainerBorder`     | Color of the border of the container (gap between meter and score container) | string |
 | `scoreColor`               | Color of the score                                                           | string |
 
-
 </div>
 
 **meterStrokeColor**
 
 <div style={{overflowX: 'auto'}}>
 
-
 | name         | description                        | type   |
 | ------------ | ---------------------------------- | ------ |
 | `excellent*` | Color when the rating is excellent | string |
 | `average*`   | Color when the rating is average   | string |
-| `poor*`     | Color when the rating is poor      | string |
-
+| `poor*`      | Color when the rating is poor      | string |
 
 </div>
 
@@ -177,12 +183,10 @@ export default ScoreMeterExample;
 
 <div style={{overflowX: 'auto'}}>
 
-
 | name         | description                                                      | type   |
 | ------------ | ---------------------------------------------------------------- | ------ |
 | `neutral*`   | Color used when there is no change in `oldReading` and `reading` | string |
 | `increment*` | Color used when `oldReading < reading`                           | string |
 | `decrement*` | Color used when `oldReading > reading`                           | string |
-
 
 </div>

--- a/src/components/Scoremeter/index.tsx
+++ b/src/components/Scoremeter/index.tsx
@@ -19,18 +19,23 @@ const ScoreMeter = (props: ScoremeterProps) => {
         colorConfig = colorGuide[colorMode == 'light' ? 'lightComponents' : 'darkComponents']
             .scoremeter,
         scoreDesc,
-        showIndicators,
+        showIndicators = false,
         lowerLimit = 300,
         upperLimit = 900,
         showLegends = true,
     } = props;
 
-    const sanitizedReading = reading < 0 ? LOWER_THRESHOLD : reading;
     const sanitizedOldReading = oldReading
-        ? oldReading < 0
-            ? LOWER_THRESHOLD
+        ? oldReading < lowerLimit
+            ? lowerLimit
+            : oldReading > upperLimit
+            ? upperLimit
             : oldReading
         : LOWER_THRESHOLD;
+
+    const sanitizedReading =
+        reading > upperLimit || reading < lowerLimit ? sanitizedOldReading : reading;
+
     const [score, setScore] = React.useState(sanitizedReading);
     const [oldScore] = React.useState(sanitizedOldReading);
     const [animate, setAnimate] = React.useState(false);

--- a/src/components/Scoremeter/index.tsx
+++ b/src/components/Scoremeter/index.tsx
@@ -25,13 +25,11 @@ const ScoreMeter = (props: ScoremeterProps) => {
         showLegends = true,
     } = props;
 
-    const sanitizedOldReading = oldReading
-        ? oldReading < lowerLimit
-            ? lowerLimit
-            : oldReading > upperLimit
-            ? upperLimit
-            : oldReading
-        : LOWER_THRESHOLD;
+    let sanitizedOldReading = LOWER_THRESHOLD;
+    if (oldReading) {
+        sanitizedOldReading = oldReading > upperLimit ? upperLimit : oldReading;
+        sanitizedOldReading = sanitizedOldReading < lowerLimit ? lowerLimit : sanitizedOldReading;
+    }
 
     const sanitizedReading =
         reading > upperLimit || reading < lowerLimit ? sanitizedOldReading : reading;

--- a/src/components/Scoremeter/types.ts
+++ b/src/components/Scoremeter/types.ts
@@ -32,7 +32,7 @@ export interface ScoremeterProps {
     colorConfig?: ScoremeterColorConfig;
     scoreDesc?: string;
     showIndicators?: boolean;
-    oldReading: number;
+    oldReading?: number;
     lowerLimit?: number;
     upperLimit?: number;
     showLegends?: boolean;


### PR DESCRIPTION
1. Added logic to check if our readings are within the specified lowerLimit and upperLimit as follows:

- If **oldReading** prop does not exists, set the **sanitizedOldReading** value to **LOWER_THRESHOLD**.
- If **oldReading** prop exists, check if its values is greater than **upperLimit** or less than **lowerLimit** and set the **sanitizedOldReading** value respectively to **upperLimit** or **lowerLimit**. If **oldReading** falls within the specified limit, set the **sanitizedOldReading** value to **oldReading** prop value.
- If **reading** prop value falls out of the specified limit range( greater than upperLimit or less than lowerLimit) then set the **sanitizedReading** value to **sanitizedOldReading** otherwise set it to **reading** prop value

2. Fixed storybook playground controls
