### PR TITLE
fix: code improvements and cleanup

### DIFF
--- a/src/components/InputField/InputField.stories.mdx
+++ b/src/components/InputField/InputField.stories.mdx
@@ -42,6 +42,10 @@ export const inputWarningArgTypes = {
     },
 };
 
+export const argTypes = {
+    inputRef: { table: { disable: true } },
+};
+
 An input field includes a label and a text field users can type text into.
 
 ## Usage
@@ -70,7 +74,7 @@ export default InputFieldExample;
 ## Variants
 
 <Canvas>
-    <Story name="InputField" args={{ ...inputArgTypes }}>
+    <Story name="InputField" args={{ ...inputArgTypes }} argTypes={argTypes}>
         {InputFieldTemplate.bind({})}
     </Story>
 </Canvas>
@@ -78,7 +82,7 @@ export default InputFieldExample;
 ### With Error Message
 
 <Canvas>
-    <Story name="InputWarningField" args={{ ...inputWarningArgTypes }}>
+    <Story name="InputWarningField" args={{ ...inputWarningArgTypes }} argTypes={argTypes}>
         {InputFieldTemplate.bind({})}
     </Story>
 </Canvas>

--- a/src/components/Toast/Toast.stories.mdx
+++ b/src/components/Toast/Toast.stories.mdx
@@ -104,7 +104,7 @@ import { mainColors } from '@cred/neopop-web/lib/primitives';
 
 const ToastDemo = () => {
     const showToastNotif = () => {
-        showToast('Sample toast message', { type: 'success', autoCloseTime: '5000' });
+        showToast('Sample toast message', { type: 'success', autoCloseTime: 5000 });
     };
 
     return <button onClick={() => showToastNotif()}>Click for toast</button>;

--- a/src/components/Toast/components/ToastPortal.tsx
+++ b/src/components/Toast/components/ToastPortal.tsx
@@ -5,7 +5,7 @@ import { typographyGuide } from '../../../primitives';
 import Typography from '../../Typography';
 import { Icon, ToastItem } from '../styles';
 import { ToastIconProps, ToastProps } from '../types';
-import { hexToRGBA } from '../../../utils';
+import { hexToRGBA, isEmpty } from '../../../utils';
 import { getToastColor } from '@primitives/toasts';
 
 const generateId = () => Math.random().toString(36).substring(2, 10);
@@ -39,7 +39,9 @@ export const Toast = (props: ToastProps) => {
             background={colorConfig.background}
             autoCloseTime={autoCloseTime}
             fullWidth={fullWidth}
-            onClick={() => (dismissOnClick && id ? removeToast?.(id) : null)}
+            onClick={() => {
+                if (dismissOnClick && id) removeToast?.(id);
+            }}
         >
             <Column>
                 <Typography {...textStyle.heading} color={colorConfig.color}>
@@ -87,7 +89,7 @@ export const ToastPortal = forwardRef((props, ref) => {
         }
     }, [toastList]);
 
-    if (!toastList?.length) return null;
+    if (isEmpty(toastList)) return null;
 
     return (
         <Portal>

--- a/src/components/Toast/components/ToastPortal.tsx
+++ b/src/components/Toast/components/ToastPortal.tsx
@@ -39,7 +39,7 @@ export const Toast = (props: ToastProps) => {
             background={colorConfig.background}
             autoCloseTime={autoCloseTime}
             fullWidth={fullWidth}
-            onClick={() => (dismissOnClick && removeToast && id ? removeToast(id) : null)}
+            onClick={() => (dismissOnClick && id ? removeToast?.(id) : null)}
         >
             <Column>
                 <Typography {...textStyle.heading} color={colorConfig.color}>
@@ -64,7 +64,6 @@ export const Toast = (props: ToastProps) => {
 
 export const ToastPortal = forwardRef((props, ref) => {
     const [toastList, setToastList] = useState<ToastProps[]>([]);
-    const [removeId, setRemoveId] = useState<string | undefined>('');
 
     useImperativeHandle(ref, () => ({
         addToast(options: ToastProps) {
@@ -79,22 +78,16 @@ export const ToastPortal = forwardRef((props, ref) => {
     };
 
     useEffect(() => {
-        if (removeId) {
-            removeToast(removeId);
-        }
-    }, [removeId]);
-
-    useEffect(() => {
         if (toastList.length) {
             const { id, autoCloseTime } = toastList[toastList.length - 1];
-            setTimeout(() => {
-                setRemoveId(id);
+            const timerId = setTimeout(() => {
+                removeToast(id);
             }, autoCloseTime || 3000);
+            return () => clearTimeout(timerId);
         }
     }, [toastList]);
 
-    if (!toastList) return null;
-    if (toastList && !toastList.length) return null;
+    if (!toastList?.length) return null;
 
     return (
         <Portal>


### PR DESCRIPTION
1. Added cleanup for `setTimeout` in useEffect.
2. Removed the useEffect which will be triggered based on the `removeId` state which will further call the `removeToast` and invoked the `removeToast` directly inside the setTimeout.
3. Code improvements
```diff
- if (!toastList) return null;
- if (toastList && !toastList.length) return null;
+ if (!toastList?.length) return null;
```
will return `null` for both falsy values(null,undefined) and empty array [ ]