### PR TITLE
docs: fix typo and add description

### DIFF
--- a/src/components/Button/Button.stories.mdx
+++ b/src/components/Button/Button.stories.mdx
@@ -147,7 +147,7 @@ There can be 2 different variants of `flat` and `elevated` kind buttton
 | `elevationDirection` | specifies the direction for an `elevated` button. this will decide which plunk to hide or show when button is pressed. <br/> `"bottom-right"` `"top-right"` `"bottom-left"` `"top-left"` `"bottom-center"` `"top-center"` `"right-center"` `"left-center"` | `string`         |
 | `fullWidth`          | flex the button to take full-width of the container                                                                                                                                                                                                        | `boolean`        |
 | `showArrow`          | arrow icon in the button                                                                                                                                                                                                                                   | `boolean`        |
-| `disabled`           | if true, button is disabled                                                                                                                                                                                                                                | `object`         |
+| `disabled`           | if true, button is disabled                                                                                                                                                                                                                                | `boolean`         |
 | `colorConfig`        | object for taking in colors                                                                                                                                                                                                                                | `object`         |
 | `spacingConfig`      | object for taking in spacing details                                                                                                                                                                                                                       | `object`         |
 | `textStyle`          | text style - passes configs for `Typography` <br/> `{ fontWeight: FontWeights, fontSize: number, fontType: FontType }`                                                                                                                                     | `object`         |
@@ -166,7 +166,7 @@ It also takes `disabledColors` which takes in the same props but applied when `d
 | `backgroundColor` | background color for the face                                                                                    | `string` |
 | `edgeColors`      | colors for the plunk (left, right, top, bottom) <br/> `{ left: color, top: color, right: color, bottom: color }` | `object` |
 | `color`           | text color                                                                                                       | `string` |
-| `disabledColors`  | object of `borderColor`, `backgroundColor`, `edgeColors`, and `color` to be applied when `disabled` is true.     | `string` |
+| `disabledColors`  | object of `borderColor`, `backgroundColor`, `edgeColors`, and `color` to be applied when `disabled` is true.     | `object` |
 
 </div>
 

--- a/src/components/InputField/InputField.stories.mdx
+++ b/src/components/InputField/InputField.stories.mdx
@@ -96,7 +96,7 @@ export default InputFieldExample;
 | name           | specifies the name                                                                       | `string`                                                                    |
 | isDisabled     | disable state                                                                            | `bool`                                                                      |
 | placeholder    | defines placeholder for the field                                                        | `string`                                                                    |
-| scrollIntoView | scrolls an element into the viewport                                                     | `bool`                                                                      |
+| scrollIntoView | scrolls an element into the viewport                                                     | `bool` &vert; `object`                                                      |
 | id             | the unique identifier for this field                                                     | `string`                                                                    |
 | label          | specifies caption for the element                                                        | `string`                                                                    |
 | type           | specifies the type of the input field                                                    | `text` , `tel` , `number`                                                   |

--- a/src/components/InputField/InputField.stories.mdx
+++ b/src/components/InputField/InputField.stories.mdx
@@ -96,7 +96,7 @@ export default InputFieldExample;
 | name           | specifies the name                                                                       | `string`                                                                    |
 | isDisabled     | disable state                                                                            | `bool`                                                                      |
 | placeholder    | defines placeholder for the field                                                        | `string`                                                                    |
-| scrollIntoView | -                                                                                        | `bool`                                                                      |
+| scrollIntoView | scrolls an element into the viewport                                                     | `bool`                                                                      |
 | id             | the unique identifier for this field                                                     | `string`                                                                    |
 | label          | specifies caption for the element                                                        | `string`                                                                    |
 | type           | specifies the type of the input field                                                    | `text` , `tel` , `number`                                                   |
@@ -106,7 +106,7 @@ export default InputFieldExample;
 | tabIndex       | indicates the element can be focused, and participates in sequential keyboard navigation | `number`                                                                    |
 | autoComplete   | specifies whether an element should have autocomplete enabled                            | `string`                                                                    |
 | onBlur         | event when an element loses focus                                                        | `func`                                                                      |
-| onFocus        | event when the user sets focus on an element                                             | `number`                                                                    |
+| onFocus        | event when the user sets focus on an element                                             | `func`                                                                      |
 | style          | for inline styles                                                                        | `React.CSSProperties`                                                       |
 | autoFocus      | specifies that an element should automatically get focus when the page loads             | `bool`                                                                      |
 | hasError       | specifies error state                                                                    | `bool`                                                                      |
@@ -148,10 +148,10 @@ export default InputFieldExample;
 
 <div style={{overflowX: 'auto'}}>
 
-| prop            | description        | type                                       |
-| --------------- | ------------------ | ------------------------------------------ |
-| `fontType*`     | typography variant | `heading`, `caps`, `body`, `serif-heading` |
-| `fontWeight*`   | weight of the text | `800`, `700`, `600`, `500`, `400`, `300`   |
-| `fontSize*`     | size of the text   | `string`                                   |
+| prop          | description        | type                                       |
+| ------------- | ------------------ | ------------------------------------------ |
+| `fontType*`   | typography variant | `heading`, `caps`, `body`, `serif-heading` |
+| `fontWeight*` | weight of the text | `800`, `700`, `600`, `500`, `400`, `300`   |
+| `fontSize*`   | size of the text   | `string`                                   |
 
 </div>

--- a/src/components/InputField/InputField.stories.mdx
+++ b/src/components/InputField/InputField.stories.mdx
@@ -94,22 +94,22 @@ export default InputFieldExample;
 | prop           | description                                                                              | type                                                                        |
 | -------------- | ---------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
 | name           | specifies the name                                                                       | `string`                                                                    |
-| isDisabled     | disable state                                                                            | `bool`                                                                      |
+| isDisabled     | disable state                                                                            | `boolean`                                                                   |
 | placeholder    | defines placeholder for the field                                                        | `string`                                                                    |
-| scrollIntoView | scrolls an element into the viewport                                                     | `bool` \| `object`                                                          |
+| scrollIntoView | scrolls an element into the viewport                                                     | `boolean` \| `object`                                                       |
 | id             | the unique identifier for this field                                                     | `string`                                                                    |
 | label          | specifies caption for the element                                                        | `string`                                                                    |
 | type           | specifies the type of the input field                                                    | `text` , `tel` , `number`                                                   |
-| onChange       | event when the user commits a value change to a form control                             | `func`                                                                      |
+| onChange       | event when the user commits a value change to a form control                             | `function`                                                                  |
 | maxLength      | specifies the maximum value                                                              | `number`                                                                    |
 | value          | specifies the value of an element                                                        | `any`                                                                       |
 | tabIndex       | indicates the element can be focused, and participates in sequential keyboard navigation | `number`                                                                    |
 | autoComplete   | specifies whether an element should have autocomplete enabled                            | `string`                                                                    |
-| onBlur         | event when an element loses focus                                                        | `func`                                                                      |
-| onFocus        | event when the user sets focus on an element                                             | `func`                                                                      |
+| onBlur         | event when an element loses focus                                                        | `function`                                                                  |
+| onFocus        | event when the user sets focus on an element                                             | `function`                                                                  |
 | style          | for inline styles                                                                        | `React.CSSProperties`                                                       |
-| autoFocus      | specifies that an element should automatically get focus when the page loads             | `bool`                                                                      |
-| hasError       | specifies error state                                                                    | `bool`                                                                      |
+| autoFocus      | specifies that an element should automatically get focus when the page loads             | `boolean`                                                                   |
+| hasError       | specifies error state                                                                    | `boolean`                                                                   |
 | inputRef       | ref attribute for input field                                                            | React.MutableRefObject<HTMLInputElement \| null>                            |
 | errorMessage   | defines error message                                                                    | `string`                                                                    |
 | colorConfig    | can be used for passing additional color configurations                                  | `object`                                                                    |

--- a/src/components/InputField/InputField.stories.mdx
+++ b/src/components/InputField/InputField.stories.mdx
@@ -96,7 +96,7 @@ export default InputFieldExample;
 | name           | specifies the name                                                                       | `string`                                                                    |
 | isDisabled     | disable state                                                                            | `bool`                                                                      |
 | placeholder    | defines placeholder for the field                                                        | `string`                                                                    |
-| scrollIntoView | scrolls an element into the viewport                                                     | `bool` &vert; `object`                                                      |
+| scrollIntoView | scrolls an element into the viewport                                                     | `bool` \| `object`                                                          |
 | id             | the unique identifier for this field                                                     | `string`                                                                    |
 | label          | specifies caption for the element                                                        | `string`                                                                    |
 | type           | specifies the type of the input field                                                    | `text` , `tel` , `number`                                                   |
@@ -110,7 +110,7 @@ export default InputFieldExample;
 | style          | for inline styles                                                                        | `React.CSSProperties`                                                       |
 | autoFocus      | specifies that an element should automatically get focus when the page loads             | `bool`                                                                      |
 | hasError       | specifies error state                                                                    | `bool`                                                                      |
-| inputRef       | ref attribute for input field                                                            | React.MutableRefObject<HTMLInputElement &vert; null>                        |
+| inputRef       | ref attribute for input field                                                            | React.MutableRefObject<HTMLInputElement \| null>                            |
 | errorMessage   | defines error message                                                                    | `string`                                                                    |
 | colorConfig    | can be used for passing additional color configurations                                  | `object`                                                                    |
 | colorMode      | dark or light                                                                            | `string`                                                                    |


### PR DESCRIPTION
1. Fixed typo in prop type
2. Added description for `scrollIntoView` prop 
3. Updated `scrollIntoView` prop type to `bool | object`, since `useScrollIntoView` hook is handling both boolean and object for scrollIntoView.