### PR TITLE
fix: global store listener cleanup

### DIFF
--- a/src/components/Toast/index.tsx
+++ b/src/components/Toast/index.tsx
@@ -13,6 +13,10 @@ class GlobalStore {
         this.func.push(listener);
     }
 
+    off(listener: Function) {
+        this.func = this.func.filter((fn) => fn !== listener);
+    }
+
     emit(options: OptionProps) {
         this.func.forEach((l) => l(options));
     }
@@ -32,6 +36,7 @@ export const ToastContainer = () => {
             toastRef.current?.addToast(options);
         };
         globalStore.on(listener);
+        return () => globalStore.off(listener);
     }, []);
 
     return <ToastPortal ref={toastRef} />;


### PR DESCRIPTION
- Cleaned up the `listener` function in `useEffect`.

**Before:**

`listener` fired **`12`** times on a single click of a
![image](https://user-images.githubusercontent.com/42532987/181409907-c218edd5-4fd6-4171-a679-1148798d3066.png)
button in storybook.

**After:** 

`listener` fired **`3`** times on a single click of a 
![image](https://user-images.githubusercontent.com/42532987/181409928-3753e051-d40d-4486-95b6-942190308044.png)
 button in storybook.