### PR TITLE
Issue #49: Adding accesibility to checkbox,button as well a radio button.

### DIFF
--- a/src/components/Button/styles.ts
+++ b/src/components/Button/styles.ts
@@ -56,6 +56,9 @@ export const ButtonWrapper = styled.button<StyledButtonType>`
             : `
 
     `}
+    &:focus {
+        outline: solid 1px white;
+    }
     .button-face {
         position: relative;
         display: flex;

--- a/src/components/Button/styles.ts
+++ b/src/components/Button/styles.ts
@@ -57,7 +57,7 @@ export const ButtonWrapper = styled.button<StyledButtonType>`
 
     `}
     &:focus {
-        outline: solid 1px white;
+        outline: auto;
     }
     .button-face {
         position: relative;

--- a/src/components/Checkbox/index.tsx
+++ b/src/components/Checkbox/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import withCheckHOC from '@components/Helpers/withCheckHOC';
 import { CheckmarkWrapper, CheckboxLabel } from './styles';
 import { CheckboxProps } from './types';
@@ -8,6 +8,7 @@ import { isEmpty } from '@utils';
 
 const Checkbox = (props: CheckboxProps) => {
     const { isChecked, handleChange, colorConfig, colorMode, children, ...propsToFwd } = props;
+    const checkboxRef = useRef<HTMLInputElement>(null);
     const defaultColorConfig =
         colorGuide[colorMode === 'light' ? 'lightComponents' : 'darkComponents'].checkbox;
     const checkboxColorConfig = isEmpty(colorConfig)
@@ -16,12 +17,32 @@ const Checkbox = (props: CheckboxProps) => {
 
     return (
         <CheckboxLabel>
-            <input {...propsToFwd} type="checkbox" checked={isChecked} onChange={handleChange} />
+            <input
+                tabIndex={-1}
+                {...propsToFwd}
+                type="checkbox"
+                checked={isChecked}
+                onChange={handleChange}
+                ref={checkboxRef}
+            />
             <Row>
                 <CheckmarkWrapper
                     colorConfig={checkboxColorConfig}
                     hasChildren={children ? true : false}
                     checked={isChecked}
+                    tabIndex={0}
+                    onClick={(clickEvent) => {
+                        clickEvent.preventDefault();
+                        checkboxRef.current?.click();
+                    }}
+                    role="checkbox"
+                    aria-checked={isChecked}
+                    onKeyDown={(keydownEvent) => {
+                        let key = keydownEvent.code;
+                        if (key === 'Space' || key === 'Enter') {
+                            checkboxRef.current?.click();
+                        }
+                    }}
                 >
                     <span className="checkmark">
                         <svg

--- a/src/components/Radio/index.tsx
+++ b/src/components/Radio/index.tsx
@@ -20,7 +20,6 @@ const Radio = (props: RadioProps) => {
             }}
             onKeyDown={(clickEvent) => {
                 const key = clickEvent.code;
-                console.log(key);
                 if (key === 'Enter' || key === 'Space') radioRef?.current?.click();
             }}
             colorConfig={

--- a/src/components/Radio/index.tsx
+++ b/src/components/Radio/index.tsx
@@ -14,10 +14,19 @@ const Radio = (props: RadioProps) => {
 
     const RadioStyledButton = () => (
         <StyledRadio
-            onClick={() => radioRef?.current?.click()}
+            onClick={(clickEvent) => {
+                clickEvent.preventDefault();
+                radioRef?.current?.click();
+            }}
+            onKeyDown={(clickEvent) => {
+                const key = clickEvent.code;
+                console.log(key);
+                if (key === 'Enter' || key === 'Space') radioRef?.current?.click();
+            }}
             colorConfig={
                 isEmpty(colorConfig) ? defaultColorConfig : colorConfig ?? defaultColorConfig
             }
+            tabIndex={0}
         >
             <input
                 id={id}
@@ -25,6 +34,7 @@ const Radio = (props: RadioProps) => {
                 type="radio"
                 checked={isChecked}
                 onChange={handleChange}
+                tabIndex={-1}
                 {...propsToFwd}
             />
             <span className="checkmark"> </span>


### PR DESCRIPTION
Issue: Not having accessibility feature in checkboxes ,buttons as well as  radio buttons.

 I wanted to contribute to the code as per what I've checked the keyboard accessibility was totally working for checkbox and buttons but there was no outline appearing for the same .
 In case of radio buttons even though u could toggle a radio with tab and select but after it you cannot move further to select next radio button.
 
 solutions:
 1-> Solved for buttons by simply providing an outline: "auto" when we focus into the component and clicking on space was already enabled.
 2-> For checkboxes as we are hiding original HTML checkbox but on pressing the tab or changing the value the focus goes to the original checkbox element because of which the outline visible outside the checkbox component on focus gets removed for this I added a ref to html checkbox to be controlled from our custom component
 3-> For radio buttons I simply added tab indexing and accessibility
